### PR TITLE
Minor python.el issue fixed

### DIFF
--- a/highlight-indentation.el
+++ b/highlight-indentation.el
@@ -42,7 +42,9 @@ indent-width will be guessed from current major-mode"
              indent-width
            ;; Set indentation offset according to major mode
            (cond ((eq major-mode 'python-mode)
-                  py-indent-offset)
+                  (if (boundp 'python-indent)
+                      python-indent
+                    py-indent-offset))
                  ((eq major-mode 'ruby-mode)
                   ruby-indent-level)
                  ((local-variable-p 'c-basic-offset)


### PR DESCRIPTION
You referenced variable `py-indent-offset` from the Python distribution's python-mode. I fixed the code to be compatible with the standard Emacs distribution's python-mode as well.

Great work!
