### PR TITLE
added support for web-mode, jade-mode and stylus-mode (derived sws-mode)

### DIFF
--- a/highlight-indentation.el
+++ b/highlight-indentation.el
@@ -78,6 +78,11 @@ on spaces"
                   js-indent-level)
                  ((eq major-mode 'js2-mode)
                   js2-basic-offset)
+		 ((eq (derived-mode-class major-mode) 'sws-mode)
+		  sws-tab-width)
+                 ((eq major-mode 'web-mode) ; multiple lang mode
+		  ; other similar vars: web-mode-{css-indent,scripts}-offset
+		  web-mode-html-offset) 
                  ((local-variable-p 'c-basic-offset)
                   c-basic-offset)
                  (t


### PR DESCRIPTION
web-mode provides multiple languages/styles per buffer, but the main (and common in this mode) is html. Also, there are multiple vars focused on the indentation offset per language under this mode, but by default set to the same value.

I think it isn't supported different highlights (offsets) per buffer under this mode. So, IMHO, providing the default offset for html is the best option nowadays.
