### PR TITLE
Removed post-command message.

### DIFF
--- a/highlight-indentation.el
+++ b/highlight-indentation.el
@@ -189,7 +189,6 @@ from major mode"
 
 (defconst highlight-indentation-current-column-hooks
   '((post-command-hook (lambda () 
-                         (message "post command")
                          (highlight-indentation-redraw-all-windows 'highlight-indentation-current-column-overlay
                                                                    'highlight-indentation-current-column-put-overlays-region)) nil t)))
 


### PR DESCRIPTION
Hi.
That message overwrites any output from commands that write to minibuffer. This is annoying.