### PR TITLE
web-mode-html-offset causes the error File mode specification error: (void-variable web-mode-html-offset)

### DIFF
--- a/highlight-indentation.el
+++ b/highlight-indentation.el
@@ -136,7 +136,7 @@
         ((and (fboundp 'derived-mode-class) (eq (derived-mode-class major-mode) 'sws-mode))
          sws-tab-width)
         ((eq major-mode 'web-mode)
-         web-mode-html-offset) ; other similar vars: web-mode-{css-indent,scripts}-offset
+         web-mode-markup-indent-offset) ; other similar vars: web-mode-{css-indent,scripts}-offset
         ((local-variable-p 'c-basic-offset)
          c-basic-offset)
         (t


### PR DESCRIPTION
This is a resolution for ```File mode specification error: (void-variable web-mode-html-offset)```

I am not 100% privy to the changes that took place but it looks like this has not been a part of web-mode for a little while.

I noticed a while ago that highlight-indentation-mode was broken in ERB templates but only now got around to figuring out why.  I recently did an update of all my packages and this error appeared.

I opened an issue with web-mode developers here https://github.com/fxbois/web-mode/issues/463 and was able to resolve the behavior completely with this PR.