### PR TITLE
Make highlighting less invasive by using `|` character.

### DIFF
--- a/highlight-indentation.el
+++ b/highlight-indentation.el
@@ -291,6 +291,7 @@ from major mode"
                 o (make-overlay pos (+ pos 1)))
           (overlay-put o overlay t)
           (overlay-put o 'priority highlight-indentation-current-column-overlay-priority)
+          (overlay-put o 'display highlight-indentation-overlay-string)
           (overlay-put o 'face 'highlight-indentation-current-column-face))
         (forward-char))
       (forward-line) ;; Next line

--- a/highlight-indentation.el
+++ b/highlight-indentation.el
@@ -17,6 +17,10 @@
 ;;; Commentary:
 ;; Customize `highlight-indentation-face', and
 ;; `highlight-indentation-current-column-face' to suit your theme.
+;;
+;; To replace the highlighting with a thin line
+;;   (setq highlight-indentation-overlay-string "|")
+;; and adapt faces.
 
 ;;; Code:
 
@@ -51,6 +55,11 @@ Known issues:
 - May not work perfectly near the bottom of the screen
 - Point appears after indent guides on blank lines"
   :type 'boolean
+  :group 'highlight-indentation)
+
+(defcustom highlight-indentation-overlay-string " "
+  "String to use for indentation guides"
+  :type '(string (choice (list " " "|")))
   :group 'highlight-indentation)
 
 (defvar highlight-indentation-overlay-priority 1)
@@ -130,6 +139,7 @@ Known issues:
                 (setq o (make-overlay p (+ p 1))))
               (overlay-put o overlay t)
               (overlay-put o 'priority highlight-indentation-overlay-priority)
+              (overlay-put o 'display highlight-indentation-overlay-string)
               (overlay-put o 'face 'highlight-indentation-face))
             (forward-char)
             (setq cur-column (current-column)))
@@ -154,7 +164,7 @@ Known issues:
                     (setq show nil))
                   (setq s (cons (concat
                                  (if show
-                                     (propertize " "
+                                     (propertize highlight-indentation-overlay-string
                                                  'face
                                                  'highlight-indentation-face)
                                    "")


### PR DESCRIPTION
Example:

    (custom-set-faces
     '(highlight-indentation-current-column-face ((t (:extend t :foreground "dark olive green"))))
     '(highlight-indentation-face ((t (:extend t :foreground "dark slate gray")))))
    (custom-set-variables
     '(highlight-indentation-overlay-string "|"))

![less_invasive_highlightning](https://user-images.githubusercontent.com/10621933/121798759-6890a480-cc28-11eb-869f-245e56ac0d95.png)