### PR TITLE
NonGNU ELPA fixes: copyright/license/version

### DIFF
--- a/highlight-indentation.el
+++ b/highlight-indentation.el
@@ -2,7 +2,7 @@
 ;; Copyright 2010-2022 Anton Johansson <anton.johansson@gmail.com>
 ;; Author: Anton Johansson <anton.johansson@gmail.com> - http://antonj.se
 ;; Created: Dec 15 23:42:04 2010
-;; Version: 0.7.0
+;; Version: 0.7.1
 ;; URL: https://github.com/antonj/Highlight-Indentation-for-Emacs
 ;;
 ;; This program is free software; you can redistribute it and/or

--- a/highlight-indentation.el
+++ b/highlight-indentation.el
@@ -1,4 +1,5 @@
 ;;; highlight-indentation.el --- Minor modes for highlighting indentation
+;; Copyright 2010-2022 Anton Johansson <anton.johansson@gmail.com>
 ;; Author: Anton Johansson <anton.johansson@gmail.com> - http://antonj.se
 ;; Created: Dec 15 23:42:04 2010
 ;; Version: 0.7.0
@@ -13,6 +14,9 @@
 ;; useful, but WITHOUT ANY WARRANTY; without even the implied
 ;; warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ;; PURPOSE.  See the GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;;
 ;;; Commentary:
 ;; Customize `highlight-indentation-face', and


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

However, NonGNU ELPA has a requirement that all files must have a clear statement of its license and copyright status. I believe the first patch here would be sufficient to fulfill this requirement.

The rules for accepting a package into NonGNU ELPA are here, for your reference:
https://git.savannah.gnu.org/cgit/emacs/nongnu.git/tree/README.org#n133

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the ";; Version: NNN" commentary header in this repository, as I do in the second patch.  NonGNU ELPA does not look at any "git tag". In the future, you can bump the package version (thereby releasing a new version) when you think it makes sense and at your convenience.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!